### PR TITLE
Fix packages.json and remove redundant information

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,18 +7,17 @@
 			"details": "https://github.com/kallepersson/Sublime-Finder",
 			"description": "Provides a command for opening Finder in the current directory",
 			"author": "Kalle Persson",
-			"labels": ["finder","integration"],
-			"homepage": "http://kallepersson.se/sublimefinder",
-			"last_modified": "2014-04-19 10:00:00",
-			"platforms": {
-				"osx": [
-					{
-						"version": "1.1.0",
-						"sublime_text": "*",
-						"url": "https://github.com/kallepersson/Sublime-Finder/archive/1.0.zip"
-					}
-				]
-			}
+			"labels": ["finder", "integration"],
+			"last_modified": "",
+			"releases": [
+				{
+					"platforms": ["osx"],
+					"version": "1.1.0",
+					"sublime_text": "*",
+					"date": "2014-04-19 10:00:00",
+					"url": "https://github.com/kallepersson/Sublime-Finder/archive/1.0.zip"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
You were mixing the 2.0 and the 1.2 spec of the schema.

Also, regarding tagged releases, refer to https://github.com/Mendor/sublime-erlyman/pull/6. You version "1.1.0" does not match the "1.0" tag too. You should push new tags for new releases.
